### PR TITLE
Extend WorkPrecisionSet to DDE problems

### DIFF
--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -199,7 +199,8 @@ function WorkPrecision(prob,alg,abstols,reltols,dts=nothing;
   return WorkPrecision(prob,abstols,reltols,errors,times,name,N)
 end
 
-function WorkPrecisionSet(prob::Union{AbstractODEProblem,AbstractDDEProblem},
+function WorkPrecisionSet(prob::Union{AbstractODEProblem,AbstractDDEProblem,
+                                      AbstractDAEProblem},
                           abstols,reltols,setups;numruns=20,
                           print_names=false,names=nothing,appxsol=nothing,
                           error_estimate=:final,

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -199,7 +199,8 @@ function WorkPrecision(prob,alg,abstols,reltols,dts=nothing;
   return WorkPrecision(prob,abstols,reltols,errors,times,name,N)
 end
 
-function WorkPrecisionSet(prob::AbstractODEProblem,abstols,reltols,setups;numruns=20,
+function WorkPrecisionSet(prob::Union{AbstractODEProblem,AbstractDDEProblem},
+                          abstols,reltols,setups;numruns=20,
                           print_names=false,names=nothing,appxsol=nothing,
                           error_estimate=:final,
                           test_dt=nothing,kwargs...)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,5 @@
 DiffEqProblemLibrary
 OrdinaryDiffEq 1.0.0
+DelayDiffEq
 StochasticDiffEq 0.0.5
 FiniteElementDiffEq 0.0.5

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, DiffEqDevTools, DiffEqProblemLibrary, DiffEqBase, Base.Test
+using OrdinaryDiffEq, DelayDiffEq, DiffEqDevTools, DiffEqProblemLibrary, DiffEqBase, Base.Test
 
 ## Setup Tests
 
@@ -96,3 +96,15 @@ setups = [Dict(:alg=>DP5())
           Dict(:alg=>Vern6())
           ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;appxsol=test_sol,save_everystep=false,numruns=20,maxiters=10000)
+
+# DDE problem
+prob = prob_dde_1delay
+
+abstols = 1./10.^(7:10)
+reltols = 1./10.^(4:7)
+sol = solve(prob, MethodOfSteps(Vern9(), max_fixedpoint_iters=1000); reltol=1e-14, abstol=1e-14)
+test_sol = TestSolution(sol)
+
+setups = [Dict(:alg => MethodOfSteps(BS3()))
+          Dict(:alg => MethodOfSteps(Tsit5()))]
+wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol)


### PR DESCRIPTION
I just noticed that currently no DDE benchmarks can be performed since no WorkPrecisionSet can be created for DDE problems. It seems this issue is caused by the restructuring in https://github.com/JuliaDiffEq/DiffEqDevTools.jl/commit/8de789c0b478abd212db1299a71798d079d19692#diff-826047b6175ac9aca7e1958367322880.