### PR TITLE
add deduce_Butcher_tableau

### DIFF
--- a/src/DiffEqDevTools.jl
+++ b/src/DiffEqDevTools.jl
@@ -42,7 +42,8 @@ export get_sample_errors
 #Plot Functions
 export stability_region
 
-#Tableus
+#Tableaus
+export deduce_Butcher_tableau
 export constructEuler, constructKutta3, constructRK4, constructRK438Rule,
        constructImplicitEuler, constructMidpointRule, constructTrapezoidalRule,
        constructLobattoIIIA4, constructLobattoIIIB2, constructLobattoIIIB4,

--- a/src/ode_tableaus.jl
+++ b/src/ode_tableaus.jl
@@ -1,3 +1,96 @@
+"""
+    deduce_Butcher_tableau(erk, T=Float64)
+
+Deduce and return the Butcher coefficients `A, b, c` by solving some
+specific ordinary differential equations using the explicit Runge-Kutta
+method `erk`. The type `T` will be used for computations and is the
+`eltype` of `A`, `b`, and `c`.
+"""
+function deduce_Butcher_tableau(erk, T=Float64)
+  # get the number of stages s
+  step_counter_s = 0
+  function f_for_s(du, u, p, t)
+    step_counter_s += 1
+    du .= zero(eltype(du))
+    nothing
+  end
+
+  tspan = (zero(T), one(T))
+  u0 = [zero(T)]
+  ode = ODEProblem(f_for_s, u0, tspan)
+  step_counter_s = 0
+  integrator = init(ode, erk, adaptive=false, dt=1.)
+  step!(integrator)
+  s = step_counter_s
+
+
+  # get the nodes c[i]
+  step_counter_c = 0
+  c = zeros(T, s)
+
+  function f_for_c(du, u, p, t)
+    step_counter_c += 1
+    if step_counter_c <= s
+      c[step_counter_c] = t
+    end
+    du .= zero(eltype(du))
+    nothing
+  end
+
+  tspan = (zero(T), one(T))
+  u0 = [zero(T)]
+  ode = ODEProblem(f_for_c, u0, tspan)
+  step_counter_c = 0
+  integrator = init(ode, erk, adaptive=false, dt=1.)
+  step!(integrator)
+
+
+  # get the weights b[i]
+  step_counter_b = 0
+  b = zeros(T, s)
+  function f_for_b(du, u, p, t)
+    step_counter_b += 1
+    for idx in 1:length(du)
+      du[idx] = step_counter_b == idx
+    end
+    nothing
+  end
+
+  tspan = (zero(T), one(T))
+  u0 = zeros(T, s)
+  ode = ODEProblem(f_for_b, u0, tspan)
+  step_counter_b = 0
+  integrator = init(ode, erk, adaptive=false, dt=1.)
+  step!(integrator)
+  for i in 1:s
+    b[i] = integrator.u[i]
+  end
+
+
+  # get the coefficients A[i,j]
+  step_counter_A = 0
+  A = zeros(T, s, s)
+  function f_for_A(du, u, p, t)
+    step_counter_A += 1
+    for idx in 1:length(du)
+      A[step_counter_A, idx] = u[idx]
+      du[idx] = step_counter_A == idx
+    end
+    nothing
+  end
+
+  tspan = (zero(T), one(T))
+  u0 = zeros(T, s)
+  ode = ODEProblem(f_for_A, u0, tspan)
+  step_counter_A = 0
+  integrator = init(ode, erk, adaptive=false, dt=1.)
+  step!(integrator)
+
+
+  A, b, c
+end
+
+
 #=
 
 Classic Verner 8(9) excluded since it's just hard to write from the paper.

--- a/test/ode_tableau_test.jl
+++ b/test/ode_tableau_test.jl
@@ -1,0 +1,135 @@
+using Test
+using LinearAlgebra
+using OrdinaryDiffEq, DiffEqDevTools
+
+
+# Since non-FSAL methods are FSAL'ed artificially in OrdinaryDiffEq.jl,
+# we need to exclude this last FSAL stage for the comparison with
+# tableaus.
+function coefficients_as_in_tableau(A, b, c, tab)
+  if size(A) == size(tab.A)
+    AA = A
+    bb = b
+    cc = c
+  else
+    AA = A[1:end-1, 1:end-1]
+    bb = b[1:end-1]
+    cc = c[1:end-1]
+  end
+  AA, bb, cc
+end
+
+
+function ode_tableau_tests(T)
+  let erk = Heun()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructHeun()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = Euler()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructEuler()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = RK4()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructRK4()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = SSPRK22()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructSSPRK22()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = SSPRK33()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructSSPRK33()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = SSPRK432()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructSSPRK43()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = SSPRK104()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructSSPRK104()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = Tsit5()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructTsitouras5()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = BS3()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructBogakiShampine3()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = BS5()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructBogakiShampine5()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = Vern7()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructVerner7()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+
+  let erk = Vern8()
+    A, b, c = deduce_Butcher_tableau(erk)
+    tab = constructVerner8()
+    AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
+    @test AA ≈ tab.A
+    @test bb ≈ tab.α
+    @test cc ≈ tab.c
+  end
+end
+
+
+ode_tableau_tests(Float32)
+ode_tableau_tests(Float64)


### PR DESCRIPTION
I've added a function `deduce_Butcher_tableau` to get the Butcher coefficients of an explicit RK method implemented in OrdinaryDiffEq.jl. This can be really useful for debugging new solvers (that are implemented using some different sets of coefficients, e.g. low storage schemes) and analyzing the schemes (since not all of them are given as Butcher tableaus).